### PR TITLE
Add optional hero highlights list

### DIFF
--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -22,6 +22,11 @@ export const heroContent = {
   title: 'Rakennamme älykästä ja kestävää tulevaisuutta Lapissa',
   description:
     'Lapland AI Lab yhdistää yritykset, tutkijat ja opiskelijat kehittämään ratkaisuja arktisten olosuhteiden haasteisiin. Tuemme ideasta pilotointiin ja autamme viemään tekoälyn käytännön hyötyihin.',
+  highlights: [
+    'Nopeat proof-of-concept -pilotit Lapin yritysten tarpeisiin',
+    'Yhteiskehittäminen korkeakoulujen ja tutkimusryhmien kanssa',
+    'Käytännön valmennukset tekoälyn hyödyntämiseen henkilöstölle',
+  ],
   primaryAction: { label: 'Varaa tapaaminen', href: '#contact' } satisfies ActionLink,
   secondaryAction: { label: 'Tutustu toimintaamme', href: '#mission' } satisfies ActionLink,
   stats: [

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -7,6 +7,7 @@ interface HeroSectionProps {
   tagline?: string
   title: string
   description: string
+  highlights?: string[]
   primaryAction: ActionLink
   secondaryAction?: ActionLink
   stats?: HeroStat[]
@@ -17,6 +18,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({
   tagline,
   title,
   description,
+  highlights,
   primaryAction,
   secondaryAction,
   stats,
@@ -44,6 +46,20 @@ const HeroSection: React.FC<HeroSectionProps> = ({
           </h1>
 
           <p className="mt-6 text-lg text-gray-300 sm:text-xl">{description}</p>
+
+          {highlights && highlights.length > 0 && (
+            <ul className="mt-8 space-y-3 text-left text-base text-white/90">
+              {highlights.map((highlight) => (
+                <li key={highlight} className="flex items-start gap-3">
+                  <span
+                    className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-sky-400"
+                    aria-hidden="true"
+                  />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          )}
 
           <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row md:justify-start">
             <ButtonLink href={primaryAction.href} variant="primary">


### PR DESCRIPTION
## Summary
- add an optional highlights array to the hero section and render it as a styled bullet list
- populate hero content with concrete highlight items for the landing page hero

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf8f65cf5c832cb4252989ccfe000a